### PR TITLE
docs: add `lang="ts"` to script in the getting started example

### DIFF
--- a/src/routes/docs/[...2]getting-started/[...2]usage/+page.md
+++ b/src/routes/docs/[...2]getting-started/[...2]usage/+page.md
@@ -5,7 +5,7 @@
 Create a new email template in the `src/$lib/emails` directory:
 
 ```svelte title="src/$lib/emails/welcome.svelte"|copy
-<script>
+<script lang="ts">
 	import { Button, Container, Head, Hr, Html, Img, Preview, Section, Text } from 'svelte-email';
 
 	export let firstName = 'John';


### PR DESCRIPTION
The example code in the getting started/usage page has typescript syntax in the `<script>` tag but doesn't specify the `lang="ts"`, leading to errors when copying the example.
https://svelte-email.vercel.app/docs/getting-started/usage

For example:
```ts
	const btnContainer = {
		textAlign: 'center' as const // it errors here
	};
```