### PR TITLE
Upgrade svelte version to 3.59.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
 	"dependencies": {
 		"html-to-text": "^9.0.3",
 		"pretty": "^2.0.0",
-		"svelte": "^3.55.1"
+		"svelte": "^3.59.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   html-to-text:
     specifier: ^9.0.3
@@ -8,8 +12,8 @@ dependencies:
     specifier: ^2.0.0
     version: 2.0.0
   svelte:
-    specifier: ^3.55.1
-    version: 3.55.1
+    specifier: ^3.59.2
+    version: 3.59.2
 
 devDependencies:
   '@iconify-json/ri':
@@ -20,13 +24,13 @@ devDependencies:
     version: 2.0.0(@sveltejs/kit@1.5.2)
   '@sveltejs/kit':
     specifier: ^1.5.0
-    version: 1.5.2(svelte@3.55.1)(vite@4.0.4)
+    version: 1.5.2(svelte@3.59.2)(vite@4.0.4)
   '@sveltejs/package':
     specifier: ^1.0.0
-    version: 1.0.2(svelte@3.55.1)(typescript@4.9.5)
+    version: 1.0.2(svelte@3.59.2)(typescript@4.9.5)
   '@svelteness/kit-docs':
     specifier: ^1.1.1
-    version: 1.1.1(svelte@3.55.1)
+    version: 1.1.1(svelte@3.59.2)
   '@types/gtag.js':
     specifier: ^0.0.12
     version: 0.0.12
@@ -59,7 +63,7 @@ devDependencies:
     version: 8.6.0(eslint@8.33.0)
   eslint-plugin-svelte3:
     specifier: ^4.0.0
-    version: 4.0.0(eslint@8.33.0)(svelte@3.55.1)
+    version: 4.0.0(eslint@8.33.0)(svelte@3.59.2)
   i:
     specifier: ^0.3.7
     version: 0.3.7
@@ -74,13 +78,13 @@ devDependencies:
     version: 2.8.3
   prettier-plugin-svelte:
     specifier: ^2.8.1
-    version: 2.9.0(prettier@2.8.3)(svelte@3.55.1)
+    version: 2.9.0(prettier@2.8.3)(svelte@3.59.2)
   shiki:
     specifier: ^0.14.0
     version: 0.14.0
   svelte-check:
     specifier: ^3.0.1
-    version: 3.0.3(postcss@8.4.21)(svelte@3.55.1)
+    version: 3.0.3(postcss@8.4.21)(svelte@3.59.2)
   tailwindcss:
     specifier: ^3.2.4
     version: 3.2.4(postcss@8.4.21)
@@ -421,11 +425,11 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
     dependencies:
-      '@sveltejs/kit': 1.5.2(svelte@3.55.1)(vite@4.0.4)
+      '@sveltejs/kit': 1.5.2(svelte@3.59.2)(vite@4.0.4)
       import-meta-resolve: 2.2.1
     dev: true
 
-  /@sveltejs/kit@1.5.2(svelte@3.55.1)(vite@4.0.4):
+  /@sveltejs/kit@1.5.2(svelte@3.59.2)(vite@4.0.4):
     resolution: {integrity: sha512-ZLi5x1dy5M4EU/NlH/fvSJ1k2wT3/04NaEOkSMJvGS0JYyFPn+H2tXbVQg7XI/eX84d5GeScxwmn4UVZWaMbsA==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -434,7 +438,7 @@ packages:
       svelte: ^3.54.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.0.2(svelte@3.55.1)(vite@4.0.4)
+      '@sveltejs/vite-plugin-svelte': 2.0.2(svelte@3.59.2)(vite@4.0.4)
       '@types/cookie': 0.5.1
       cookie: 0.5.0
       devalue: 4.2.3
@@ -445,7 +449,7 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.5.1
       sirv: 2.0.2
-      svelte: 3.55.1
+      svelte: 3.59.2
       tiny-glob: 0.2.9
       undici: 5.18.0
       vite: 4.0.4
@@ -453,7 +457,7 @@ packages:
       - supports-color
     dev: true
 
-  /@sveltejs/package@1.0.2(svelte@3.55.1)(typescript@4.9.5):
+  /@sveltejs/package@1.0.2(svelte@3.59.2)(typescript@4.9.5):
     resolution: {integrity: sha512-VY9U+05d9uNFDj7ScKRlHORYlfPSHwJewBjV+V2RsnViexpLFPUrboC9SiPYDCpLnbeqwXerxhO6twGHUBGeIA==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -463,13 +467,13 @@ packages:
       chokidar: 3.5.3
       kleur: 4.1.5
       sade: 1.8.1
-      svelte: 3.55.1
-      svelte2tsx: 0.6.1(svelte@3.55.1)(typescript@4.9.5)
+      svelte: 3.59.2
+      svelte2tsx: 0.6.1(svelte@3.59.2)(typescript@4.9.5)
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@2.0.2(svelte@3.55.1)(vite@4.0.4):
+  /@sveltejs/vite-plugin-svelte@2.0.2(svelte@3.59.2)(vite@4.0.4):
     resolution: {integrity: sha512-xCEan0/NNpQuL0l5aS42FjwQ6wwskdxC3pW1OeFtEKNZwRg7Evro9lac9HesGP6TdFsTv2xMes5ASQVKbCacxg==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -480,15 +484,15 @@ packages:
       deepmerge: 4.3.0
       kleur: 4.1.5
       magic-string: 0.27.0
-      svelte: 3.55.1
-      svelte-hmr: 0.15.1(svelte@3.55.1)
+      svelte: 3.59.2
+      svelte-hmr: 0.15.1(svelte@3.59.2)
       vite: 4.0.4
       vitefu: 0.2.4(vite@4.0.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@svelteness/kit-docs@1.1.1(svelte@3.55.1):
+  /@svelteness/kit-docs@1.1.1(svelte@3.59.2):
     resolution: {integrity: sha512-vNcdV6fQP4uKLS9dY1qrDuQAiCDSf9iLAdxgT9U7f5ORhbcCzok/uTo51T8L0ZjOaU0m4SCmQkgfyKR52a0Fsw==}
     engines: {node: '>=14.19.0'}
     dependencies:
@@ -497,7 +501,7 @@ packages:
       clsx: 1.2.1
       kleur: 4.1.5
       shiki: 0.11.1
-      svelte-class-transition: 1.0.4(svelte@3.55.1)
+      svelte-class-transition: 1.0.4(svelte@3.59.2)
     transitivePeerDependencies:
       - svelte
     dev: true
@@ -1110,14 +1114,14 @@ packages:
       eslint: 8.33.0
     dev: true
 
-  /eslint-plugin-svelte3@4.0.0(eslint@8.33.0)(svelte@3.55.1):
+  /eslint-plugin-svelte3@4.0.0(eslint@8.33.0)(svelte@3.59.2):
     resolution: {integrity: sha512-OIx9lgaNzD02+MDFNLw0GEUbuovNcglg+wnd/UY0fbZmlQSz7GlQiQ1f+yX0XvC07XPcDOnFcichqI3xCwp71g==}
     peerDependencies:
       eslint: '>=8.0.0'
       svelte: ^3.2.0
     dependencies:
       eslint: 8.33.0
-      svelte: 3.55.1
+      svelte: 3.59.2
     dev: true
 
   /eslint-scope@5.1.1:
@@ -2047,14 +2051,14 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-svelte@2.9.0(prettier@2.8.3)(svelte@3.55.1):
+  /prettier-plugin-svelte@2.9.0(prettier@2.8.3)(svelte@3.59.2):
     resolution: {integrity: sha512-3doBi5NO4IVgaNPtwewvrgPpqAcvNv0NwJNflr76PIGgi9nf1oguQV1Hpdm9TI2ALIQVn/9iIwLpBO5UcD2Jiw==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
       svelte: ^3.2.0
     dependencies:
       prettier: 2.8.3
-      svelte: 3.55.1
+      svelte: 3.59.2
     dev: true
 
   /prettier@2.8.3:
@@ -2305,7 +2309,7 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /svelte-check@3.0.3(postcss@8.4.21)(svelte@3.55.1):
+  /svelte-check@3.0.3(postcss@8.4.21)(svelte@3.59.2):
     resolution: {integrity: sha512-ByBFXo3bfHRGIsYEasHkdMhLkNleVfszX/Ns1oip58tPJlKdo5Ssr8kgVIuo5oq00hss8AIcdesuy0Xt0BcTvg==}
     hasBin: true
     peerDependencies:
@@ -2317,8 +2321,8 @@ packages:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 3.55.1
-      svelte-preprocess: 5.0.1(postcss@8.4.21)(svelte@3.55.1)(typescript@4.9.5)
+      svelte: 3.59.2
+      svelte-preprocess: 5.0.1(postcss@8.4.21)(svelte@3.59.2)(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -2332,24 +2336,24 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-class-transition@1.0.4(svelte@3.55.1):
+  /svelte-class-transition@1.0.4(svelte@3.59.2):
     resolution: {integrity: sha512-00Rs6Ft5V9v4aqHIZKZHY2/OUQjFSNBXtG53ped3SEyl0kYiOyXu/16Ro3xsKMyaU4/xppoL8ef5uPoSP+BNPw==}
     peerDependencies:
       svelte: ^3.21.0
     dependencies:
-      svelte: 3.55.1
+      svelte: 3.59.2
     dev: true
 
-  /svelte-hmr@0.15.1(svelte@3.55.1):
+  /svelte-hmr@0.15.1(svelte@3.59.2):
     resolution: {integrity: sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: '>=3.19.0'
     dependencies:
-      svelte: 3.55.1
+      svelte: 3.59.2
     dev: true
 
-  /svelte-preprocess@5.0.1(postcss@8.4.21)(svelte@3.55.1)(typescript@4.9.5):
+  /svelte-preprocess@5.0.1(postcss@8.4.21)(svelte@3.59.2)(typescript@4.9.5):
     resolution: {integrity: sha512-0HXyhCoc9rsW4zGOgtInylC6qj259E1hpFnJMJWTf+aIfeqh4O/QHT31KT2hvPEqQfdjmqBR/kO2JDkkciBLrQ==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
@@ -2394,11 +2398,11 @@ packages:
       postcss: 8.4.21
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 3.55.1
+      svelte: 3.59.2
       typescript: 4.9.5
     dev: true
 
-  /svelte2tsx@0.6.1(svelte@3.55.1)(typescript@4.9.5):
+  /svelte2tsx@0.6.1(svelte@3.59.2)(typescript@4.9.5):
     resolution: {integrity: sha512-O/1+5UyChfmhp1/GUv8b8iveTrn6eZwHxEXc+rw7LMKRidr9KHk5w/EiliLjDUwHa2VA6CoEty+CQylROVU4Sw==}
     peerDependencies:
       svelte: ^3.55
@@ -2406,12 +2410,12 @@ packages:
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 3.55.1
+      svelte: 3.59.2
       typescript: 4.9.5
     dev: true
 
-  /svelte@3.55.1:
-    resolution: {integrity: sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==}
+  /svelte@3.59.2:
+    resolution: {integrity: sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==}
     engines: {node: '>= 8'}
 
   /tailwindcss@3.2.4(postcss@8.4.21):


### PR DESCRIPTION
Library has type errors due to breaking changes in svelte 3.58. Fixes #11 
