### PR TITLE
Add Columns to utilize Sections (tables)

### DIFF
--- a/src/routes/docs/[...6]examples/[...1]airbnb-review/Email.svelte
+++ b/src/routes/docs/[...6]examples/[...1]airbnb-review/Email.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import {
 		Button,
+		Column,
 		Container,
 		Head,
 		Heading,
@@ -107,42 +108,48 @@
 	<Head />
 	<Preview preview={previewText} />
 	<Section style={main}>
-		<Container style={container}>
-			<Img src={`${baseUrl}/airbnb-logo.png`} width="96" height="30" alt="Airbnb" />
-			<Section>
-				<Img src={authorImage} width="96" height="96" alt={authorName} style={userImage} />
-			</Section>
-			<Heading style={heading}>Here's what {authorName} wrote</Heading>
-			<Text style={review}>{reviewText}</Text>
-			<Text style={paragraph}>
-				Now that the review period is over, we’ve posted {authorName}’s review to your Airbnb
-				profile.
-			</Text>
-			<Text style={paragraph}>
-				While it’s too late to write a review of your own, you can send your feedback to {authorName}
-				using your Airbnb message thread.
-			</Text>
-			<Section style={{ padding: '16px 0 20px' }}>
-				<Button pY={19} style={button} href="https://airbnb.com/">Send My Feedback</Button>
-			</Section>
-			<Hr style={hr} />
-			<Text style={{ ...paragraph, fontWeight: '700' }}>Common questions</Text>
-			<Text>
-				<Link href="https://airbnb.com/help/article/13" style={link}>How do reviews work?</Link>
-			</Text>
-			<Text>
-				<Link href="https://airbnb.com/help/article/1257" style={link}>
-					How do star ratings work?
-				</Link>
-			</Text>
-			<Text>
-				<Link href="https://airbnb.com/help/article/995" style={link}>
-					Can I leave a review after 14 days?
-				</Link>
-			</Text>
-			<Hr style={hr} />
-			<Text style={footer}>Airbnb, Inc., 888 Brannan St, San Francisco, CA 94103</Text>
-			<Link href="https://airbnb.com" style={reportLink}>Report unsafe behavior</Link>
-		</Container>
+		<Column>
+			<Container style={container}>
+				<Img src={`${baseUrl}/airbnb-logo.png`} width="96" height="30" alt="Airbnb" />
+				<Section>
+					<Column>
+						<Img src={authorImage} width="96" height="96" alt={authorName} style={userImage} />
+					</Column>
+				</Section>
+				<Heading style={heading}>Here's what {authorName} wrote</Heading>
+				<Text style={review}>{reviewText}</Text>
+				<Text style={paragraph}>
+					Now that the review period is over, we’ve posted {authorName}’s review to your Airbnb
+					profile.
+				</Text>
+				<Text style={paragraph}>
+					While it’s too late to write a review of your own, you can send your feedback to {authorName}
+					using your Airbnb message thread.
+				</Text>
+				<Section style={{ padding: '16px 0 20px' }}>
+					<Column>
+						<Button pY={19} style={button} href="https://airbnb.com/">Send My Feedback</Button>
+					</Column>
+				</Section>
+				<Hr style={hr} />
+				<Text style={{ ...paragraph, fontWeight: '700' }}>Common questions</Text>
+				<Text>
+					<Link href="https://airbnb.com/help/article/13" style={link}>How do reviews work?</Link>
+				</Text>
+				<Text>
+					<Link href="https://airbnb.com/help/article/1257" style={link}>
+						How do star ratings work?
+					</Link>
+				</Text>
+				<Text>
+					<Link href="https://airbnb.com/help/article/995" style={link}>
+						Can I leave a review after 14 days?
+					</Link>
+				</Text>
+				<Hr style={hr} />
+				<Text style={footer}>Airbnb, Inc., 888 Brannan St, San Francisco, CA 94103</Text>
+				<Link href="https://airbnb.com" style={reportLink}>Report unsafe behavior</Link>
+			</Container>
+		</Column>
 	</Section>
 </Html>

--- a/src/routes/docs/[...6]examples/[...1]apple-receipt/Email.svelte
+++ b/src/routes/docs/[...6]examples/[...1]apple-receipt/Email.svelte
@@ -1,17 +1,6 @@
 <script lang="ts">
 	// @ts-nocheck
-	import {
-		Column,
-		Container,
-		Head,
-		Hr,
-		Html,
-		Img,
-		Link,
-		Preview,
-		Section,
-		Text
-	} from '$lib';
+	import { Column, Container, Head, Hr, Html, Img, Link, Preview, Section, Text } from '$lib';
 	import { styleToString } from '$lib/utils';
 
 	const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '';
@@ -235,241 +224,245 @@
 	<Head />
 	<Preview preview="Apple Receipt" />
 	<Section style={main}>
-		<Container style={container}>
-			<Section>
-				<Column>
-					<Img src={`${baseUrl}/apple-logo.png`} width="42" height="42" alt="Apple Logo" />
-				</Column>
+		<Column>
+			<Container style={container}>
+				<Section>
+					<Column>
+						<Img src={`${baseUrl}/apple-logo.png`} width="42" height="42" alt="Apple Logo" />
+					</Column>
 
-				<Column align="right" style={tableCell}>
-					<Text style={heading}>Receipt</Text>
-				</Column>
-			</Section>
-			<Section>
-				<Text style={cupomText}>
-					Save 3% on all your Apple purchases with Apple Card.
-					<sup style={styleToString(supStyle)}>1</sup>{' '}
-					<Link href="https://www.apple.com/apple-card">Apply and use in minutes</Link>
-					<sup style={styleToString(supStyle)}>2</sup>
-				</Text>
-			</Section>
-			<table style={styleToString(informationTable)}>
-				<tbody>
-					<tr style={styleToString(informationTableRow)}>
-						<td style={styleToString(informationTableColumn)} width={320} colSpan={2}>
-							<span style={styleToString(informationTableLabel)}>APPLE ID</span>
+					<Column align="right" style={tableCell}>
+						<Text style={heading}>Receipt</Text>
+					</Column>
+				</Section>
+				<Section>
+					<Column>
+						<Text style={cupomText}>
+							Save 3% on all your Apple purchases with Apple Card.
+							<sup style={styleToString(supStyle)}>1</sup>{' '}
+							<Link href="https://www.apple.com/apple-card">Apply and use in minutes</Link>
+							<sup style={styleToString(supStyle)}>2</sup>
+						</Text>
+					</Column>
+				</Section>
+				<table style={styleToString(informationTable)}>
+					<tbody>
+						<tr style={styleToString(informationTableRow)}>
+							<td style={styleToString(informationTableColumn)} width={320} colSpan={2}>
+								<span style={styleToString(informationTableLabel)}>APPLE ID</span>
+								<br />
+								<Link>zeno.rocha@gmail.com</Link>
+							</td>
+							<td width={340} style={styleToString(informationTableColumn)} rowSpan={3}>
+								<span style={styleToString(informationTableLabel)}>BILLED TO</span>
+								<br />
+								Visa .... 7461 (Apple Pay)
+								<br />
+								Zeno Rocha
+								<br />
+								2125 Chestnut St
+								<br />
+								San Francisco, CA 94123
+								<br />
+								USA
+							</td>
+						</tr>
+						<tr style={styleToString(informationTableRow)}>
+							<td style={styleToString(informationTableColumn)} colSpan={2}>
+								<span style={styleToString(informationTableLabel)}>DATE</span>
+								<br />
+								Jul 20, 2023
+							</td>
+						</tr>
+						<tr style={styleToString(informationTableRow)}>
+							<td style={styleToString(informationTableColumn)}>
+								<span style={styleToString(informationTableLabel)}>ORDER ID</span>
+								<br />
+								<Link
+									href="https://support.apple.com/kb/HT204088?cid=email_receipt_itunes_article_HT204088"
+								>
+									ML4F5L8522
+								</Link>
+							</td>
+							<td style={styleToString(informationTableColumn)}>
+								<span style={styleToString(informationTableColumn)}>DOCUMENT NO.</span>
+								<br />
+								<Link>121565300446</Link>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<Section style={productTitleTable}>
+					<Column>
+						<Text style={productsTitle}>App Store</Text>
+					</Column>
+				</Section>
+				<Section>
+					<Column>
+						<Img
+							src={`${baseUrl}/apple-hbo-max-icon.jpeg`}
+							width="64"
+							height="64"
+							alt="HBO Max"
+							style={productIcon}
+						/>
+					</Column>
+					<Column>
+						<Text style={productDescriptionWrapper}>
+							<span dir="auto" style={styleToString(productTitle)}>
+								HBO Max: Stream TV &amp; Movies
+							</span>
 							<br />
-							<Link>zeno.rocha@gmail.com</Link>
-						</td>
-						<td width={340} style={styleToString(informationTableColumn)} rowSpan={3}>
-							<span style={styleToString(informationTableLabel)}>BILLED TO</span>
+							<span style={styleToString(productDescription)}> HBO Max Ad-Free (Monthly) </span>
 							<br />
-							Visa .... 7461 (Apple Pay)
-							<br />
-							Zeno Rocha
-							<br />
-							2125 Chestnut St
-							<br />
-							San Francisco, CA 94123
-							<br />
-							USA
-						</td>
-					</tr>
-					<tr style={styleToString(informationTableRow)}>
-						<td style={styleToString(informationTableColumn)} colSpan={2}>
-							<span style={styleToString(informationTableLabel)}>DATE</span>
-							<br />
-							Jul 20, 2023
-						</td>
-					</tr>
-					<tr style={styleToString(informationTableRow)}>
-						<td style={styleToString(informationTableColumn)}>
-							<span style={styleToString(informationTableLabel)}>ORDER ID</span>
+							<span style={styleToString(productDescription)}>Renews Aug 20, 2023</span>
 							<br />
 							<Link
-								href="https://support.apple.com/kb/HT204088?cid=email_receipt_itunes_article_HT204088"
+								href="https://userpub.itunes.apple.com/WebObjects/MZUserPublishing.woa/wa/addUserReview?cc=us&amp;id=1497977514&amp;o=i&amp;type=Subscription%20Renewal"
+								style={productLink}
+								data-saferedirecturl="https://www.google.com/url?q=https://userpub.itunes.apple.com/WebObjects/MZUserPublishing.woa/wa/addUserReview?cc%3Dus%26id%3D1497977514%26o%3Di%26type%3DSubscription%2520Renewal&amp;source=gmail&amp;ust=1673963081204000&amp;usg=AOvVaw2DFCLKMo1snS-Swk5H26Z1"
 							>
-								ML4F5L8522
+								Write a Review
 							</Link>
-						</td>
-						<td style={styleToString(informationTableColumn)}>
-							<span style={styleToString(informationTableColumn)}>DOCUMENT NO.</span>
-							<br />
-							<Link>121565300446</Link>
-						</td>
-					</tr>
-				</tbody>
-			</table>
+							&nbsp;|&nbsp;<span>&nbsp;</span>
+							<span>&nbsp;</span>
+							<Link
+								href="https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/reportAProblem?a=1497977514&amp;cc=us&amp;d=683263808&amp;o=i&amp;p=29065684906671&amp;pli=29092219632071&amp;s=1"
+								style={productLink}
+								data-saferedirecturl="https://www.google.com/url?q=https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/reportAProblem?a%3D1497977514%26cc%3Dus%26d%3D683263808%26o%3Di%26p%3D29065684906671%26pli%3D29092219632071%26s%3D1&amp;source=gmail&amp;ust=1673963081204000&amp;usg=AOvVaw3y47L06B2LTrL6qsmaW2Hq"
+							>
+								Report a Problem
+							</Link>
+						</Text>
+					</Column>
 
-			<Section style={productTitleTable}>
-				<Column>
-					<Text style={productsTitle}>App Store</Text>
-				</Column>
-			</Section>
-			<Section>
-				<Column>
-					<Img
-						src={`${baseUrl}/apple-hbo-max-icon.jpeg`}
-						width="64"
-						height="64"
-						alt="HBO Max"
-						style={productIcon}
-					/>
-				</Column>
-				<Column>
-					<Text style={productDescriptionWrapper}>
-						<span dir="auto" style={styleToString(productTitle)}>
-							HBO Max: Stream TV &amp; Movies
-						</span>
-						<br />
-						<span style={styleToString(productDescription)}> HBO Max Ad-Free (Monthly) </span>
-						<br />
-						<span style={styleToString(productDescription)}>Renews Aug 20, 2023</span>
-						<br />
+					<Column style={productPriceWrapper} align="right">
+						<span style={styleToString(productPrice)}>$14.99</span>
+					</Column>
+				</Section>
+				<Hr style={productPriceLine} />
+				<Section align="right">
+					<Column style={tableCell} align="right">
+						<Text style={productPriceTotal}>TOTAL</Text>
+					</Column>
+					<Column style={productPriceVerticalLine} />
+					<Column style={productPriceLargeWrapper}>
+						<Text style={productPriceLarge}>$14.99</Text>
+					</Column>
+				</Section>
+				<Hr style={productPriceLineBottom} />
+				<Section>
+					<Column align="center" style={block}>
+						<Img src={`${baseUrl}/apple-card-icon.png`} width="60" height="17" alt="Apple Card" />
+					</Column>
+				</Section>
+				<Section>
+					<Column align="center" style={ctaTitle}>
+						<Text style={ctaText}>Save 3% on all your Apple purchases.</Text>
+					</Column>
+				</Section>
+				<Section>
+					<Column align="center" style={walletWrapper}>
 						<Link
-							href="https://userpub.itunes.apple.com/WebObjects/MZUserPublishing.woa/wa/addUserReview?cc=us&amp;id=1497977514&amp;o=i&amp;type=Subscription%20Renewal"
-							style={productLink}
-							data-saferedirecturl="https://www.google.com/url?q=https://userpub.itunes.apple.com/WebObjects/MZUserPublishing.woa/wa/addUserReview?cc%3Dus%26id%3D1497977514%26o%3Di%26type%3DSubscription%2520Renewal&amp;source=gmail&amp;ust=1673963081204000&amp;usg=AOvVaw2DFCLKMo1snS-Swk5H26Z1"
+							href="https://wallet.apple.com/apple-card/setup/feature/ccs?referrer=cid%3Dapy-120-100003"
+							style={walletLink}
 						>
-							Write a Review
+							<Img
+								src={`${baseUrl}/apple-wallet.png`}
+								width="28"
+								height="28"
+								alt="Apple Wallet"
+								style={walletImage}
+							/>
+							<span style={styleToString(walletLinkText)}>Apply and use in minutes</span>
 						</Link>
-						&nbsp;|&nbsp;<span>&nbsp;</span>
-						<span>&nbsp;</span>
-						<Link
-							href="https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/reportAProblem?a=1497977514&amp;cc=us&amp;d=683263808&amp;o=i&amp;p=29065684906671&amp;pli=29092219632071&amp;s=1"
-							style={productLink}
-							data-saferedirecturl="https://www.google.com/url?q=https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/reportAProblem?a%3D1497977514%26cc%3Dus%26d%3D683263808%26o%3Di%26p%3D29065684906671%26pli%3D29092219632071%26s%3D1&amp;source=gmail&amp;ust=1673963081204000&amp;usg=AOvVaw3y47L06B2LTrL6qsmaW2Hq"
-						>
-							Report a Problem
-						</Link>
-					</Text>
-				</Column>
-
-				<Column style={productPriceWrapper} align="right">
-					<span style={styleToString(productPrice)}>$14.99</span>
-				</Column>
-			</Section>
-			<Hr style={productPriceLine} />
-			<Section align="right">
-				<Column style={tableCell} align="right">
-					<Text style={productPriceTotal}>TOTAL</Text>
-				</Column>
-				<Column style={productPriceVerticalLine} />
-				<Column style={productPriceLargeWrapper}>
-					<Text style={productPriceLarge}>$14.99</Text>
-				</Column>
-			</Section>
-			<Hr style={productPriceLineBottom} />
-			<Section>
-				<Column align="center" style={block}>
-					<Img src={`${baseUrl}/apple-card-icon.png`} width="60" height="17" alt="Apple Card" />
-				</Column>
-			</Section>
-			<Section>
-				<Column align="center" style={ctaTitle}>
-					<Text style={ctaText}>Save 3% on all your Apple purchases.</Text>
-				</Column>
-			</Section>
-			<Section>
-				<Column align="center" style={walletWrapper}>
-					<Link
-						href="https://wallet.apple.com/apple-card/setup/feature/ccs?referrer=cid%3Dapy-120-100003"
-						style={walletLink}
-					>
-						<Img
-							src={`${baseUrl}/apple-wallet.png`}
-							width="28"
-							height="28"
-							alt="Apple Wallet"
-							style={walletImage}
-						/>
-						<span style={styleToString(walletLinkText)}>Apply and use in minutes</span>
+					</Column>
+				</Section>
+				<Hr style={walletBottomLine} />
+				<Text style={footerText}>
+					1. 3% savings is earned as Daily Cash and is transferred to your Apple Cash card when
+					transactions post to your Apple Card account. If you do not have an Apple Cash card, Daily
+					Cash can be applied by you as a credit on your statement balance. 3% is the total amount
+					of Daily Cash earned for these purchases. See the Apple Card Customer Agreement for more
+					details on Daily Cash and qualifying transactions.
+					<br />
+					<br />
+					2. Subject to credit approval.
+					<br />
+					<br />
+					To access and use all the features of Apple Card, you must add Apple Card to Wallet on an iPhone
+					or iPad with iOS or iPadOS 13.2 or later. Update to the latest version of iOS or iPadOS by
+					going to Settings &gt; General &gt; Software Update. Tap Download and Install.
+					<br />
+					<br />
+					Available for qualifying applicants in the United States.
+					<br />
+					<br />
+					Apple Card is issued by Goldman Sachs Bank USA, Salt Lake City Branch.
+					<br />
+					<br />
+					If you reside in the US territories, please call Goldman Sachs at 877-255-5923 with questions
+					about Apple Card.
+				</Text>
+				<Text style={footerTextCenter}>
+					Privacy: We use a
+					<Link href="http://support.apple.com/kb/HT207233" style={footerLink}>
+						{' '}
+						Subscriber ID{' '}
 					</Link>
-				</Column>
-			</Section>
-			<Hr style={walletBottomLine} />
-			<Text style={footerText}>
-				1. 3% savings is earned as Daily Cash and is transferred to your Apple Cash card when
-				transactions post to your Apple Card account. If you do not have an Apple Cash card, Daily
-				Cash can be applied by you as a credit on your statement balance. 3% is the total amount of
-				Daily Cash earned for these purchases. See the Apple Card Customer Agreement for more
-				details on Daily Cash and qualifying transactions.
-				<br />
-				<br />
-				2. Subject to credit approval.
-				<br />
-				<br />
-				To access and use all the features of Apple Card, you must add Apple Card to Wallet on an iPhone
-				or iPad with iOS or iPadOS 13.2 or later. Update to the latest version of iOS or iPadOS by going
-				to Settings &gt; General &gt; Software Update. Tap Download and Install.
-				<br />
-				<br />
-				Available for qualifying applicants in the United States.
-				<br />
-				<br />
-				Apple Card is issued by Goldman Sachs Bank USA, Salt Lake City Branch.
-				<br />
-				<br />
-				If you reside in the US territories, please call Goldman Sachs at 877-255-5923 with questions
-				about Apple Card.
-			</Text>
-			<Text style={footerTextCenter}>
-				Privacy: We use a
-				<Link href="http://support.apple.com/kb/HT207233" style={footerLink}>
-					{' '}
-					Subscriber ID{' '}
-				</Link>
-				to provide reports to developers.
-			</Text>
-			<Text style={footerTextCenter}>
-				Get help with subscriptions and purchases.
-				<Link href="https://support.apple.com/billing?cid=email_receipt" style={footerLink}>
-					Visit Apple Support.
-				</Link>
-				<br />
-				<br />
-				Learn how to{' '}
-				<Link
-					href="https://support.apple.com/kb/HT204030?cid=email_receipt_itunes_article_HT204030"
-				>
-					manage your password preferences
-				</Link>{' '}
-				for iTunes, Apple Books, and App Store purchases.
-				<br />
-				<br />
-				<br />
-				You have the option to stop receiving email receipts for your subscription renewals. If you have
-				opted out, you can still view your receipts in your account under Purchase History. To manage
-				receipts or to opt in again, go to{' '}
-				<Link
-					href="https://finance-app.itunes.apple.com/account/subscriptions?unsupportedRedirectUrl=https://apps.apple.com/US/invoice"
-				>
-					Account Settings.
-				</Link>
-			</Text>
+					to provide reports to developers.
+				</Text>
+				<Text style={footerTextCenter}>
+					Get help with subscriptions and purchases.
+					<Link href="https://support.apple.com/billing?cid=email_receipt" style={footerLink}>
+						Visit Apple Support.
+					</Link>
+					<br />
+					<br />
+					Learn how to{' '}
+					<Link
+						href="https://support.apple.com/kb/HT204030?cid=email_receipt_itunes_article_HT204030"
+					>
+						manage your password preferences
+					</Link>{' '}
+					for iTunes, Apple Books, and App Store purchases.
+					<br />
+					<br />
+					<br />
+					You have the option to stop receiving email receipts for your subscription renewals. If you
+					have opted out, you can still view your receipts in your account under Purchase History. To
+					manage receipts or to opt in again, go to{' '}
+					<Link
+						href="https://finance-app.itunes.apple.com/account/subscriptions?unsupportedRedirectUrl=https://apps.apple.com/US/invoice"
+					>
+						Account Settings.
+					</Link>
+				</Text>
 
-			<Section>
-				<Column align="center" style={footerIcon}>
-					<Img src={`${baseUrl}/apple-logo.png`} width="26" height="26" alt="Apple Card" />
-				</Column>
-			</Section>
+				<Section>
+					<Column align="center" style={footerIcon}>
+						<Img src={`${baseUrl}/apple-logo.png`} width="26" height="26" alt="Apple Card" />
+					</Column>
+				</Section>
 
-			<Text style={footerLinksWrapper}>
-				<Link href="https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/accountSummary?mt=8">
-					Account Settings
-				</Link>{' '}
-				•{' '}
-				<Link href="https://www.apple.com/legal/itunes/us/sales.html">Terms of Sale</Link>{' '}
-				•{' '}
-				<Link href="https://www.apple.com/legal/privacy/">
-					Privacy Policy{' '}
-				</Link>
-			</Text>
+				<Text style={footerLinksWrapper}>
+					<Link href="https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/accountSummary?mt=8">
+						Account Settings
+					</Link>{' '}
+					•{' '}
+					<Link href="https://www.apple.com/legal/itunes/us/sales.html">Terms of Sale</Link>{' '}
+					•{' '}
+					<Link href="https://www.apple.com/legal/privacy/">
+						Privacy Policy{' '}
+					</Link>
+				</Text>
 
-			<Text style={footerCopyright}>
-				Copyright © 2023 Apple Inc. <br />{' '}
-				<Link href="https://www.apple.com/legal/">All rights reserved</Link>
-			</Text>
-		</Container>
+				<Text style={footerCopyright}>
+					Copyright © 2023 Apple Inc. <br />{' '}
+					<Link href="https://www.apple.com/legal/">All rights reserved</Link>
+				</Text>
+			</Container>
+		</Column>
 	</Section>
 </Html>


### PR DESCRIPTION
This PR aims to remove empty tables from the email examples, specifically the Airbnb Review Notification and Apple Receipt templates.

Through my investigation, I discovered that the `Section` component's opening tag must be followed by the `Column` component, which renders the `<td>` tag. If this sequence is not maintained, the `Section` components can result in empty tables throughout the templates, causing components that should be wrapped by tables to appear on their own.
