### PR TITLE
Replace 'component' with 'template' in integrations

### DIFF
--- a/src/routes/docs/[...5]integrations/[...2]nodemailer/+page.md
+++ b/src/routes/docs/[...5]integrations/[...2]nodemailer/+page.md
@@ -57,7 +57,7 @@ const transporter = nodemailer.createTransport({
 });
 
 const emailHtml = render({
-	component: Hello,
+	template: Hello,
 	props: {
 		name: 'Svelte'
 	}

--- a/src/routes/docs/[...5]integrations/[...3]sendgrid/+page.md
+++ b/src/routes/docs/[...5]integrations/[...3]sendgrid/+page.md
@@ -44,7 +44,7 @@ import sendgrid from '@sendgrid/mail';
 sendgrid.setApiKey(process.env.SENDGRID_API_KEY);
 
 const emailHtml = render({
-	component: Hello,
+	template: Hello,
 	props: {
 		name: 'Svelte'
 	}

--- a/src/routes/docs/[...5]integrations/[...4]postmark/+page.md
+++ b/src/routes/docs/[...5]integrations/[...4]postmark/+page.md
@@ -44,7 +44,7 @@ import postmark from 'postmark';
 const client = new postmark.ServerClient(process.env.POSTMARK_API_KEY);
 
 const emailHtml = render({
-	component: Hello,
+	template: Hello,
 	props: {
 		name: 'Svelte'
 	}

--- a/src/routes/docs/[...5]integrations/[...5]aws-ses/+page.md
+++ b/src/routes/docs/[...5]integrations/[...5]aws-ses/+page.md
@@ -44,7 +44,7 @@ import AWS from 'aws-sdk';
 AWS.config.update({ region: process.env.AWS_SES_REGION });
 
 const emailHtml = render({
-	component: Hello,
+	template: Hello,
 	props: {
 		name: 'Svelte'
 	}


### PR DESCRIPTION
This PR is to address this issue https://github.com/carstenlebek/svelte-email/issues/5.

The code snippets in the integrations is wrong and causes this error error when run. 

```bash
TypeError: Cannot read properties of undefined (reading 'render')
    at Module.render (project_name/node_modules/svelte-email/render.js:10:14)
    at GET (project_name/src/routes/api/invite/teacher/+server.js:22:43)
    at Module.render_endpoint (project_name/node_modules/@sveltejs/kit/src/runtime/server/endpoint.js:49:24)
```

Instead of passing `component` into `render`, rather I have replaced it with `template`.