### PR TITLE
Update Column.svelte ARIA role attribute

### DIFF
--- a/src/lib/components/Column.svelte
+++ b/src/lib/components/Column.svelte
@@ -22,6 +22,6 @@
 	};
 </script>
 
-<td style={styleToString(styleDefault)} role="presentation" {...$$restProps} class={className}>
+<td style={styleToString(styleDefault)} role="row" {...$$restProps} class={className}>
 	<slot />
 </td>


### PR DESCRIPTION
Fix "<td> cannot have role 'presentation'" a11y warning