### PR TITLE
Update Packaging to get rid of warning in Sveltekit 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+dist

--- a/package.json
+++ b/package.json
@@ -8,18 +8,94 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "svelte-kit sync && svelte-package",
+		"package": "svelte-kit sync && svelte-package && publint",
 		"docs:build": "svelte-kit sync && vite build",
-		"prepublishOnly": "echo 'Did you mean to publish `./package/`, instead of `./`?' && exit 1",
+		"prepublishOnly": "npm run package",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
 		"format": "prettier --plugin-search-dir . --write ."
 	},
+	"files": [
+		"dist",
+		"package.json",
+		"README.md"
+	],
+	"svelte": "./dist/index.js",
+	"main": "./dist/index.js",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"svelte": "./dist/index.js"
+		},
+		"./package.json": {
+			"default": "./package.json"
+		},
+		"./components/Body.svelte": {
+			"types": "./dist/components/Body.svelte.d.ts",
+			"svelte": "./dist/components/Body.svelte"
+		},
+		"./components/Column.svelte": {
+			"types": "./dist/components/Column.svelte.d.ts",
+			"svelte": "./dist/components/Column.svelte"
+		},
+		"./components/Container.svelte": {
+			"types": "./dist/components/Container.svelte.d.ts",
+			"svelte": "./dist/components/Container.svelte"
+		},
+		"./components/Head.svelte": {
+			"types": "./dist/components/Head.svelte.d.ts",
+			"svelte": "./dist/components/Head.svelte"
+		},
+		"./components/Heading.svelte": {
+			"types": "./dist/components/Heading.svelte.d.ts",
+			"svelte": "./dist/components/Heading.svelte"
+		},
+		"./components/Hr.svelte": {
+			"types": "./dist/components/Hr.svelte.d.ts",
+			"svelte": "./dist/components/Hr.svelte"
+		},
+		"./components/Html.svelte": {
+			"types": "./dist/components/Html.svelte.d.ts",
+			"svelte": "./dist/components/Html.svelte"
+		},
+		"./components/Img.svelte": {
+			"types": "./dist/components/Img.svelte.d.ts",
+			"svelte": "./dist/components/Img.svelte"
+		},
+		"./components/Link.svelte": {
+			"types": "./dist/components/Link.svelte.d.ts",
+			"svelte": "./dist/components/Link.svelte"
+		},
+		"./components/Preview.svelte": {
+			"types": "./dist/components/Preview.svelte.d.ts",
+			"svelte": "./dist/components/Preview.svelte"
+		},
+		"./components/Section.svelte": {
+			"types": "./dist/components/Section.svelte.d.ts",
+			"svelte": "./dist/components/Section.svelte"
+		},
+		"./components/Text.svelte": {
+			"types": "./dist/components/Text.svelte.d.ts",
+			"svelte": "./dist/components/Text.svelte"
+		},
+		"./render": {
+			"types": "./dist/render.d.ts",
+			"default": "./dist/render.js"
+		},
+		"./utils": {
+			"types": "./dist/utils.d.ts",
+			"default": "./dist/utils.js"
+		}
+	},
+	"peerDependencies": {
+		"@sveltejs/kit": "^1.5.0 || ^2.0.0"
+	},
 	"devDependencies": {
 		"@iconify-json/ri": "^1.1.4",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/kit": "^1.5.0",
-		"@sveltejs/package": "^1.0.0",
+		"@sveltejs/package": "^2.2.5",
 		"@svelteness/kit-docs": "^1.1.1",
 		"@types/gtag.js": "^0.0.12",
 		"@types/html-to-text": "^9.0.0",
@@ -37,6 +113,7 @@
 		"postcss": "^8.4.21",
 		"prettier": "^2.8.0",
 		"prettier-plugin-svelte": "^2.8.1",
+		"publint": "^0.2.7",
 		"shiki": "^0.14.0",
 		"svelte-check": "^3.0.1",
 		"tailwindcss": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   html-to-text:
     specifier: ^9.0.3
@@ -22,8 +26,8 @@ devDependencies:
     specifier: ^1.5.0
     version: 1.5.2(svelte@3.55.1)(vite@4.0.4)
   '@sveltejs/package':
-    specifier: ^1.0.0
-    version: 1.0.2(svelte@3.55.1)(typescript@4.9.5)
+    specifier: ^2.2.5
+    version: 2.2.5(svelte@3.55.1)(typescript@4.9.5)
   '@svelteness/kit-docs':
     specifier: ^1.1.1
     version: 1.1.1(svelte@3.55.1)
@@ -75,6 +79,9 @@ devDependencies:
   prettier-plugin-svelte:
     specifier: ^2.8.1
     version: 2.9.0(prettier@2.8.3)(svelte@3.55.1)
+  publint:
+    specifier: ^0.2.7
+    version: 0.2.7
   shiki:
     specifier: ^0.14.0
     version: 0.14.0
@@ -453,18 +460,19 @@ packages:
       - supports-color
     dev: true
 
-  /@sveltejs/package@1.0.2(svelte@3.55.1)(typescript@4.9.5):
-    resolution: {integrity: sha512-VY9U+05d9uNFDj7ScKRlHORYlfPSHwJewBjV+V2RsnViexpLFPUrboC9SiPYDCpLnbeqwXerxhO6twGHUBGeIA==}
+  /@sveltejs/package@2.2.5(svelte@3.55.1)(typescript@4.9.5):
+    resolution: {integrity: sha512-H0dFDrp7b/tr4zrUzOfqPKHG8y6ceNlGKPfSpp4ym1kTPWP79Mea5rvDlcmsbOS26FmHN/vttubalBdOCGA6qA==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     peerDependencies:
-      svelte: ^3.44.0
+      svelte: ^3.44.0 || ^4.0.0
     dependencies:
       chokidar: 3.5.3
       kleur: 4.1.5
       sade: 1.8.1
+      semver: 7.5.4
       svelte: 3.55.1
-      svelte2tsx: 0.6.1(svelte@3.55.1)(typescript@4.9.5)
+      svelte2tsx: 0.6.27(svelte@3.55.1)(typescript@4.9.5)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -810,7 +818,6 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: false
 
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -1389,7 +1396,6 @@ packages:
       inherits: 2.0.4
       minimatch: 5.1.6
       once: 1.4.0
-    dev: false
 
   /globals@13.20.0:
     resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
@@ -1466,6 +1472,13 @@ packages:
   /i@0.3.7:
     resolution: {integrity: sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==}
     engines: {node: '>=0.4'}
+    dev: true
+
+  /ignore-walk@5.0.1:
+    resolution: {integrity: sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      minimatch: 5.1.6
     dev: true
 
   /ignore@5.2.4:
@@ -1715,7 +1728,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: false
 
   /minimist@1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
@@ -1783,6 +1795,29 @@ packages:
   /normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /npm-bundled@2.0.1:
+    resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      npm-normalize-package-bin: 2.0.0
+    dev: true
+
+  /npm-normalize-package-bin@2.0.0:
+    resolution: {integrity: sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dev: true
+
+  /npm-packlist@5.1.3:
+    resolution: {integrity: sha512-263/0NGrn32YFYi4J533qzrQ/krmmrWwhKkzwTuM4f/07ug51odoaNjUexxO4vxlzURHcmYMH1QjvHjsNDKLVg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      glob: 8.1.0
+      ignore-walk: 5.0.1
+      npm-bundled: 2.0.1
+      npm-normalize-package-bin: 2.0.0
     dev: true
 
   /npm-run-path@4.0.1:
@@ -2080,6 +2115,16 @@ packages:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: false
 
+  /publint@0.2.7:
+    resolution: {integrity: sha512-tLU4ee3110BxWfAmCZggJmCUnYWgPTr0QLnx08sqpLYa8JHRiOudd+CgzdpfU5x5eOaW2WMkpmOrFshRFYK7Mw==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      npm-packlist: 5.1.3
+      picocolors: 1.0.0
+      sade: 1.8.1
+    dev: true
+
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
@@ -2188,6 +2233,14 @@ packages:
 
   /semver@7.3.8:
     resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -2398,11 +2451,11 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /svelte2tsx@0.6.1(svelte@3.55.1)(typescript@4.9.5):
-    resolution: {integrity: sha512-O/1+5UyChfmhp1/GUv8b8iveTrn6eZwHxEXc+rw7LMKRidr9KHk5w/EiliLjDUwHa2VA6CoEty+CQylROVU4Sw==}
+  /svelte2tsx@0.6.27(svelte@3.55.1)(typescript@4.9.5):
+    resolution: {integrity: sha512-E1uPW1o6VsbRz+nUk3fznZ2lSmCITAJoNu8AYefWSvIwE2pSB01i5sId4RMbWNzfcwCQl1DcgGShCPcldl4rvg==}
     peerDependencies:
-      svelte: ^3.55
-      typescript: ^4.9.4
+      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
+      typescript: ^4.9.4 || ^5.0.0
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2


### PR DESCRIPTION
## Description
This package is using an old pattern of packaging Svelte components that causes error with the newest version of the Svelte Vite plugin used in Sveltekit 2

![image](https://github.com/carstenlebek/svelte-email/assets/44912991/e407473f-d9ec-4c04-84d6-4918322976f3)

## Changes
- Updated to latest version of @sveltejs/package
- Implemented recommendations from @sveltejs/package
   - Files are now served from /dist
   - exports fields added
- Added `publint` to lint package and fixed linting errors
  - sveltekit is now correctly flagged as a peerDependency