### PR TITLE
fixes examples on the render function on the integrations pages

### DIFF
--- a/src/routes/docs/[...5]integrations/[...2]nodemailer/+page.md
+++ b/src/routes/docs/[...5]integrations/[...2]nodemailer/+page.md
@@ -57,7 +57,7 @@ const transporter = nodemailer.createTransport({
 });
 
 const emailHtml = render({
-	component: Hello,
+	template: Hello,
 	props: {
 		name: 'Svelte'
 	}

--- a/src/routes/docs/[...5]integrations/[...3]sendgrid/+page.md
+++ b/src/routes/docs/[...5]integrations/[...3]sendgrid/+page.md
@@ -44,7 +44,7 @@ import sendgrid from '@sendgrid/mail';
 sendgrid.setApiKey(process.env.SENDGRID_API_KEY);
 
 const emailHtml = render({
-	component: Hello,
+	template: Hello,
 	props: {
 		name: 'Svelte'
 	}

--- a/src/routes/docs/[...5]integrations/[...4]postmark/+page.md
+++ b/src/routes/docs/[...5]integrations/[...4]postmark/+page.md
@@ -44,7 +44,7 @@ import postmark from 'postmark';
 const client = new postmark.ServerClient(process.env.POSTMARK_API_KEY);
 
 const emailHtml = render({
-	component: Hello,
+	template: Hello,
 	props: {
 		name: 'Svelte'
 	}

--- a/src/routes/docs/[...5]integrations/[...5]aws-ses/+page.md
+++ b/src/routes/docs/[...5]integrations/[...5]aws-ses/+page.md
@@ -44,7 +44,7 @@ import AWS from 'aws-sdk';
 AWS.config.update({ region: process.env.AWS_SES_REGION });
 
 const emailHtml = render({
-	component: Hello,
+	template: Hello,
 	props: {
 		name: 'Svelte'
 	}


### PR DESCRIPTION
The examples on the integrations pages incorrectly listed a property named "component" instead of the correct property "template".

This corrects those examples.